### PR TITLE
NuGet Update

### DIFF
--- a/3D Cube/C#/3DCube.csproj
+++ b/3D Cube/C#/3DCube.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/3D Cube/C#/packages.config
+++ b/3D Cube/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/BrainRadio/C#/BrainRadio.csproj
+++ b/BrainRadio/C#/BrainRadio.csproj
@@ -45,8 +45,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -69,8 +69,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/BrainRadio/C#/packages.config
+++ b/BrainRadio/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/BrainTouchPiano/C#/BrainTouchPiano.csproj
+++ b/BrainTouchPiano/C#/BrainTouchPiano.csproj
@@ -56,8 +56,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -80,8 +80,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/BrainTouchPiano/C#/packages.config
+++ b/BrainTouchPiano/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/BurglarAlarm/C#/BurglarAlarm.csproj
+++ b/BurglarAlarm/C#/BurglarAlarm.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/BurglarAlarm/C#/packages.config
+++ b/BurglarAlarm/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/ClassicFootball/C#/ClassicFootball.csproj
+++ b/ClassicFootball/C#/ClassicFootball.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/ClassicFootball/C#/packages.config
+++ b/ClassicFootball/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/ColorMixer/C#/ColorMixer.csproj
+++ b/ColorMixer/C#/ColorMixer.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/ColorMixer/C#/packages.config
+++ b/ColorMixer/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/ElectronicDice/C#/ElectronicDice.csproj
+++ b/ElectronicDice/C#/ElectronicDice.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/ElectronicDice/C#/packages.config
+++ b/ElectronicDice/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/EtchASketch/C#/EtchASketch.csproj
+++ b/EtchASketch/C#/EtchASketch.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/EtchASketch/C#/packages.config
+++ b/EtchASketch/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/HighLowThermometer/C#/HighLowThermometer.csproj
+++ b/HighLowThermometer/C#/HighLowThermometer.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/HighLowThermometer/C#/packages.config
+++ b/HighLowThermometer/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/LinearClock/C#/LinearClock.csproj
+++ b/LinearClock/C#/LinearClock.csproj
@@ -43,8 +43,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -67,8 +67,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/LinearClock/C#/Program.cs
+++ b/LinearClock/C#/Program.cs
@@ -18,17 +18,18 @@ namespace LinearClock {
             bool ok = false;
 
             var i2cSettings = new I2cConnectionSettings(0b01101111) {
-                SharingMode = I2cSharingMode.Shared,
                 BusSpeed = I2cBusSpeed.FastMode,
             };
-            var realTimeClock = I2cDevice.FromId(GHIElectronics.TinyCLR.Pins.BrainPad.Expansion.I2cBus.I2c1, i2cSettings);
+            var realTimeClock = I2cController.FromName(GHIElectronics.TinyCLR.Pins.BrainPadBP2.I2cBus.I2c1).GetDevice(i2cSettings);
 
-            var spiSettings = new SpiConnectionSettings(GHIElectronics.TinyCLR.Pins.BrainPad.Expansion.GpioPin.Cs) {
+            var spiSettings = new SpiConnectionSettings() {
+                ChipSelectType = SpiChipSelectType.Gpio,
+                ChipSelectLine = GHIElectronics.TinyCLR.Pins.BrainPad.Expansion.GpioPin.Cs,
                 Mode = SpiMode.Mode0,
                 ClockFrequency = 20000000,
                 DataBitLength = 8,
             };
-            var ledStrip = SpiDevice.FromId(GHIElectronics.TinyCLR.Pins.BrainPad.Expansion.SpiBus.Spi1, spiSettings);
+            var ledStrip = SpiController.FromName(GHIElectronics.TinyCLR.Pins.BrainPadBP2.SpiBus.Spi1).GetDevice(spiSettings);
 
             while (true) {
                 i2cReadData[0] = (0x00);

--- a/LinearClock/C#/packages.config
+++ b/LinearClock/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/MarbleSortingRobot/C#/MarbleSortingRobot.csproj
+++ b/MarbleSortingRobot/C#/MarbleSortingRobot.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/MarbleSortingRobot/C#/packages.config
+++ b/MarbleSortingRobot/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/Pong/C#/Pong.csproj
+++ b/Pong/C#/Pong.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/Pong/C#/packages.config
+++ b/Pong/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/SnapCircuitsLiftOff/C#/SnapCircuitsLiftOff.csproj
+++ b/SnapCircuitsLiftOff/C#/SnapCircuitsLiftOff.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/SnapCircuitsLiftOff/C#/packages.config
+++ b/SnapCircuitsLiftOff/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/SpaceForceRobot/C#/SpaceForceRobot.csproj
+++ b/SpaceForceRobot/C#/SpaceForceRobot.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/SpaceForceRobot/C#/packages.config
+++ b/SpaceForceRobot/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/SpaceInvasion/C#/SpaceInvasion.csproj
+++ b/SpaceInvasion/C#/SpaceInvasion.csproj
@@ -44,8 +44,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -68,8 +68,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/SpaceInvasion/C#/packages.config
+++ b/SpaceInvasion/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/TiltEtchASketch/C#/TiltEtchASketch.csproj
+++ b/TiltEtchASketch/C#/TiltEtchASketch.csproj
@@ -46,8 +46,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -70,8 +70,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/TiltEtchASketch/C#/packages.config
+++ b/TiltEtchASketch/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />

--- a/TiltMaze/C#/TiltMaze.csproj
+++ b/TiltMaze/C#/TiltMaze.csproj
@@ -51,8 +51,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.0\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.BrainPad, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.BrainPad.1.0.1\lib\net452\GHIElectronics.TinyCLR.BrainPad.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Devices.Adc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Adc.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Adc.dll</HintPath>
@@ -75,8 +75,8 @@
     <Reference Include="GHIElectronics.TinyCLR.Devices.Uart, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Devices.Uart.1.0.0\lib\net452\GHIElectronics.TinyCLR.Devices.Uart.dll</HintPath>
     </Reference>
-    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
+    <Reference Include="GHIElectronics.TinyCLR.Drawing, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\GHIElectronics.TinyCLR.Drawing.1.0.1\lib\net452\GHIElectronics.TinyCLR.Drawing.dll</HintPath>
     </Reference>
     <Reference Include="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.1.0.0\lib\net452\GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735.dll</HintPath>

--- a/TiltMaze/C#/packages.config
+++ b/TiltMaze/C#/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.BrainPad" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Core" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Adc" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Display" version="1.0.0" targetFramework="net452" />
@@ -9,7 +9,7 @@
   <package id="GHIElectronics.TinyCLR.Devices.Pwm" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Spi" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Devices.Uart" version="1.0.0" targetFramework="net452" />
-  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.0" targetFramework="net452" />
+  <package id="GHIElectronics.TinyCLR.Drawing" version="1.0.1" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.Sitronix.ST7735" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Drivers.SolomonSystech.SSD1306" version="1.0.0" targetFramework="net452" />
   <package id="GHIElectronics.TinyCLR.Native" version="1.0.0" targetFramework="net452" />


### PR DESCRIPTION
Updated the TinyCLR.BrainPad and TinyCLR.Drawing NuGet packages to 1.0.1 to fix a drawing issue with some of the projects and to have library continuity for the remaining projects.